### PR TITLE
test: Playwright responsive + cross-browser suite (AGENTS-32/33)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,41 +1,45 @@
 import { defineConfig, devices } from '@playwright/test'
-
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
 import 'dotenv/config'
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
+const BASE_URL = process.env.PLAYWRIGHT_BASE_URL ?? 'https://develom.com'
+
 export default defineConfig({
   testDir: './tests/e2e',
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  retries: process.env.CI ? 2 : 1,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: [['html', { open: 'never' }], ['list']],
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    baseURL: BASE_URL,
     trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
   },
   projects: [
+    // --- Desktop browsers (AGENTS-33) ---
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
+      name: 'Desktop Chrome',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'Desktop Firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'Desktop Safari',
+      use: { ...devices['Desktop Safari'] },
+    },
+    // --- Mobile viewports (AGENTS-32) ---
+    {
+      name: 'Mobile Chrome (Pixel 7)',
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'Mobile Safari (iPhone 14)',
+      use: { ...devices['iPhone 14'] },
+    },
+    {
+      name: 'Tablet (iPad Pro)',
+      use: { ...devices['iPad Pro 11'] },
     },
   ],
-  webServer: {
-    command: 'pnpm dev',
-    reuseExistingServer: true,
-    url: 'http://localhost:3000',
-  },
 })

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -1,0 +1,165 @@
+import { test, expect } from '@playwright/test'
+
+const PAGES = [
+  { path: '/', name: 'Homepage' },
+  { path: '/solutions', name: 'Solutions' },
+  { path: '/use-cases', name: 'Use Cases' },
+  { path: '/services', name: 'Services' },
+  { path: '/about', name: 'About' },
+  { path: '/portfolio', name: 'Portfolio' },
+  { path: '/contact', name: 'Contact' },
+  { path: '/blog', name: 'Blog' },
+  { path: '/pricing', name: 'Pricing' },
+  { path: '/terms', name: 'Terms' },
+  { path: '/privacy-policy', name: 'Privacy Policy' },
+]
+
+const REDIRECTS = [
+  { from: '/get-started', to: '/contact' },
+  { from: '/team', to: '/about' },
+]
+
+test.describe('Page rendering — all browsers and viewports', () => {
+  for (const { path, name } of PAGES) {
+    test(`${name} (${path}) renders with content`, async ({ page }) => {
+      const response = await page.goto(path, { waitUntil: 'domcontentloaded' })
+      expect(response?.status(), `${name}: expected 200`).toBe(200)
+
+      // Meaningful heading or landmark present
+      const heading = page.locator('h1, h2').first()
+      await expect(heading, `${name}: no h1/h2 found`).toBeVisible()
+
+      // Page has a title
+      const title = await page.title()
+      expect(title.length, `${name}: empty page title`).toBeGreaterThan(0)
+      expect(title, `${name}: title should mention Develom`).toMatch(/develom/i)
+    })
+  }
+})
+
+test.describe('Redirects', () => {
+  for (const { from, to } of REDIRECTS) {
+    test(`${from} redirects to ${to}`, async ({ page }) => {
+      await page.goto(from)
+      await expect(page).toHaveURL(new RegExp(to.replace('/', '\\/')))
+    })
+  }
+})
+
+test.describe('Mobile responsiveness', () => {
+  test('no horizontal scroll on homepage', async ({ page, viewport }) => {
+    await page.goto('/')
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth)
+    const clientWidth = await page.evaluate(() => document.documentElement.clientWidth)
+    expect(scrollWidth, `horizontal overflow at ${viewport?.width}px`).toBeLessThanOrEqual(clientWidth + 1)
+  })
+
+  test('no horizontal scroll on solutions page', async ({ page, viewport }) => {
+    await page.goto('/solutions')
+    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth)
+    const clientWidth = await page.evaluate(() => document.documentElement.clientWidth)
+    expect(scrollWidth, `horizontal overflow at ${viewport?.width}px`).toBeLessThanOrEqual(clientWidth + 1)
+  })
+
+  test('nav is visible and usable', async ({ page, viewport }) => {
+    await page.goto('/')
+    const isMobile = (viewport?.width ?? 1280) < 768
+
+    if (isMobile) {
+      // Mobile: hamburger or mobile nav trigger should exist
+      const mobileNav = page.locator('[aria-label*="menu" i], button[aria-expanded], .hamburger, nav button').first()
+      // Either a mobile menu button exists, or nav links are directly visible
+      const navLinks = page.locator('nav a')
+      const navVisible = await navLinks.first().isVisible().catch(() => false)
+      const mobileMenuExists = await mobileNav.count().then(n => n > 0)
+      expect(navVisible || mobileMenuExists, 'mobile: neither nav links nor mobile menu trigger found').toBeTruthy()
+    } else {
+      // Desktop: nav links should be visible
+      const navLinks = page.locator('nav a')
+      await expect(navLinks.first(), 'desktop: no nav links visible').toBeVisible()
+    }
+  })
+
+  test('CTA buttons are visible on homepage', async ({ page }) => {
+    await page.goto('/')
+    const cta = page.locator('a[href*="contact"], button').filter({ hasText: /get started|contact|talk|schedule|book/i }).first()
+    await expect(cta, 'no CTA button found on homepage').toBeVisible()
+  })
+
+  test('contact form renders on /contact', async ({ page }) => {
+    await page.goto('/contact')
+    const form = page.locator('form').first()
+    await expect(form, 'no form found on /contact').toBeVisible()
+    const nameInput = page.locator('input[name="name"], input[placeholder*="name" i]').first()
+    await expect(nameInput, 'name input not found').toBeVisible()
+  })
+})
+
+test.describe('Cross-browser visual consistency', () => {
+  test('homepage hero section renders', async ({ page }) => {
+    await page.goto('/')
+    const hero = page.locator('section, [class*="hero"], [class*="Hero"]').first()
+    await expect(hero, 'hero section not found').toBeVisible()
+  })
+
+  test('footer renders with links', async ({ page }) => {
+    await page.goto('/')
+    const footer = page.locator('footer').first()
+    await expect(footer, 'footer not found').toBeVisible()
+    const footerLinks = footer.locator('a')
+    const count = await footerLinks.count()
+    expect(count, 'footer has no links').toBeGreaterThan(0)
+  })
+
+  test('blog listing page renders posts', async ({ page }) => {
+    await page.goto('/blog')
+    const response = await page.goto('/blog', { waitUntil: 'domcontentloaded' })
+    expect(response?.status()).toBe(200)
+    const heading = page.locator('h1, h2').first()
+    await expect(heading).toBeVisible()
+  })
+
+  test('solutions page has all 6 clusters', async ({ page }) => {
+    await page.goto('/solutions')
+    const pageText = await page.locator('body').innerText()
+    const clusters = [
+      'Build the Foundation',
+      'Serve Customers',
+      'Automate Operations',
+      'Unlock Your Data',
+      'Protect',
+      'Empower',
+    ]
+    for (const cluster of clusters) {
+      expect(pageText, `cluster "${cluster}" not found on /solutions`).toMatch(new RegExp(cluster, 'i'))
+    }
+  })
+
+  test('no broken images on homepage', async ({ page }) => {
+    await page.goto('/')
+    const brokenImages = await page.evaluate(() => {
+      const imgs = Array.from(document.querySelectorAll('img'))
+      return imgs
+        .filter((img) => !img.complete || img.naturalWidth === 0)
+        .map((img) => img.src)
+    })
+    expect(brokenImages, `broken images: ${brokenImages.join(', ')}`).toHaveLength(0)
+  })
+})
+
+test.describe('OG metadata', () => {
+  test('homepage has og:title and og:image', async ({ page }) => {
+    await page.goto('/')
+    const ogTitle = await page.locator('meta[property="og:title"]').getAttribute('content')
+    const ogImage = await page.locator('meta[property="og:image"]').getAttribute('content')
+    expect(ogTitle, 'og:title missing').toBeTruthy()
+    expect(ogImage, 'og:image missing').toBeTruthy()
+  })
+
+  test('blog post has per-post og:image', async ({ page }) => {
+    await page.goto('/blog/musk-vs-openai-2026')
+    const ogImage = await page.locator('meta[property="og:image"]').getAttribute('content')
+    expect(ogImage, 'blog post og:image missing').toBeTruthy()
+    expect(ogImage, 'blog post og:image should not be generic default').not.toMatch(/og-default/)
+  })
+})


### PR DESCRIPTION
## Summary
Adds automated browser testing to close AGENTS-32 (mobile responsiveness) and AGENTS-33 (cross-browser).

## Changes

### `playwright.config.ts`
- Replaced single-browser config with 6 projects: Desktop Chrome, Firefox, Safari (webkit), Mobile Chrome (Pixel 7), Mobile Safari (iPhone 14), Tablet (iPad Pro 11)
- `baseURL` defaults to `https://develom.com`, overridable via `PLAYWRIGHT_BASE_URL` env var
- Removed `webServer` block — tests run against the deployed site, not localhost
- Screenshots on failure, HTML report

### `tests/e2e/responsive.spec.ts` (new)
Test suites:
- **Page rendering** — all 11 pages return 200, have h1/h2, have a Develom title
- **Redirects** — `/get-started` → `/contact`, `/team` → `/about`
- **Mobile responsiveness** — no horizontal scroll at any viewport, nav accessible on mobile, CTA visible, contact form renders
- **Cross-browser visual** — hero, footer, blog listing, /solutions 6-cluster check, no broken images on homepage
- **OG metadata** — og:title + og:image on homepage, per-post image on blog posts

## Running locally
```bash
npx playwright install
npx playwright test tests/e2e/responsive.spec.ts
# or against a local server:
PLAYWRIGHT_BASE_URL=http://localhost:3000 npx playwright test tests/e2e/responsive.spec.ts
```

## Test plan
- [ ] All 6 browser/device projects pass against `develom.com`
- [ ] No horizontal scroll failures on mobile viewports
- [ ] Redirect assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)