### PR TITLE
Remove NewsWidget from homepage

### DIFF
--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from 'next'
 import { getPayload } from 'payload'
 import config from '@payload-config'
 import HeroSection from '@/components/home/HeroSection'
-import NewsWidget from '@/components/home/NewsWidget'
 import TrustStrip from '@/components/home/TrustStrip'
 import SolutionsOutcome from '@/components/home/SolutionsOutcome'
 import SolutionFinder from '@/components/home/SolutionFinder'
@@ -71,7 +70,6 @@ export default async function HomePage() {
   return (
     <>
       <HeroSection />
-      <NewsWidget />
       {complianceItems.length > 0 && <ComplianceCalendar items={complianceItems} />}
       <TrustStrip />
       <SolutionsOutcome />


### PR DESCRIPTION
## Summary
- Removes `<NewsWidget />` from the homepage and its import
- The component file (`src/components/home/NewsWidget.tsx`) is left intact for future restoration
- Reason: the banner shows stale CMS timestamps ("Updated X months ago") which signals neglect rather than activity. It only adds value when there is active content velocity behind it.

## Restore conditions
Re-add `<NewsWidget />` to `page.tsx` when:
- Blog publishing is running on a regular cadence (bi-weekly or better), or
- The LatestModels collection is being updated to track AI model releases in real time

## Test plan
- [ ] Verify homepage renders without the What's New banner
- [ ] Confirm no console errors (unused import removed)
- [ ] Check hero → ComplianceCalendar flow looks clean without the strip between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)